### PR TITLE
Fix missing comma with multiple spans

### DIFF
--- a/includes/dahdi_cards.class.php
+++ b/includes/dahdi_cards.class.php
@@ -1539,6 +1539,9 @@ class dahdi_cards {
 									$fxx[$fx] .= $chan;
 							}
 						} else {
+							if(!empty($fxx[$fx])){
+								$fxx[$fx] .= ',';
+							}
 							$fxx[$fx] .= $s['startchan'].'-'.$s['endchan'].',';
 						}
 					}


### PR DESCRIPTION
Perhaps I have a misconfiguration, but my 2 spans were generating this broken config:
```
span=1,0,0,ESF,B8ZS
span=2,0,0,ESF,B8ZS
fxols=1-2425-48
echocanceller=oslec,1-2425-48
loadzone=us
defaultzone=us
```
This small patch copies 2 lines from the branch above to prepend a comma if needed.